### PR TITLE
fix: http trasversal vulnerability

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.21      
+        go-version: 1.22     
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21 
+          go-version: 1.22 
       - 
         name: Test
         run: go test -v ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2024-03-12
+
+### Security
+
+- Fix HTTP directory traversal vulnerability.
+- Dir parameter will be used as trusted root.
+
+### Changed
+
+- Trusted root is obtained from dir parameter after get the absolut and cannonical path.
+
+### Fixed
+
+- Fix README.md error marked by linter
+
+### Added
+
+- Adding Make file
+
 ## [1.0.5] - 2024-01-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Trusted root is obtained from dir parameter after get the absolut and canonical path.
+- Module go version changed to 1.22
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Trusted root is obtained from dir parameter after get the absolut and cannonical path.
+- Trusted root is obtained from dir parameter after get the absolut and canonical path.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.DEFAULT_GOAL := build
+.PHONY: fmt vet build
+fmt:
+		go fmt ./...
+
+vet: fmt 
+		go vet ./...
+
+build: vet
+		go build .

--- a/README.md
+++ b/README.md
@@ -1,50 +1,59 @@
 # dir2opds - serve books from a directory
+
  dir2opds inspects the given folder and serves an OPDS 1.1 compliant server.
 
-# Overview
- There are good options to serve books using OPDS. Calibre is good for
- that, but if your server is headless, installing Calibre doesn't seem to
- be the best option.
+## Overview
 
- That is why calibre2opds exists, but if you have too many books and
- you don't want to create a Calibre library, dir2opds could help you to
- have an OPDS server from a directory with one condition:
+There are good options for serving books using OPDS. Calibre is a popular
+choice, but if you have a headless server, installing Calibre might not be
+the best option.
 
- - A folder should have only folders or only files.
+That's where calibre2opds comes in. However, if you have a large number of
+books and don't want to create a Calibre library, dir2opds can help you
+set up an OPDS server from a directory with one condition:
 
-# Change log
-  - [Changelog](CHANGELOG.md)
+- A folder should contain either only folders or only files.
 
-# Installation
-    go install github.com/dubyte/dir2opds@latest
+## Change log
 
-# Usage
+- [Changelog](CHANGELOG.md)
+
+## Installation
+
+```bash
+go install github.com/dubyte/dir2opds@latest
+```
+
+## Usage
+
 ```bash
 Usage of dir2opds:
   -calibre
-    	Hide files stored by calibre
+      Hide files stored by calibre
   -debug
-    	If it is set, it will log the requests
+      If it is set, it will log the requests
   -dir string
-    	A directory with books (default "./books")
+      A directory with books (default "./books")
   -host string
-    	The server will listen in this host (default "0.0.0.0")
+      The server will listen in this host (default "0.0.0.0")
   -port string
-    	The server will listen in this port (default "8080")
-
+      The server will listen in this port (default "8080")
 ```
 
-# Tested on:
-   - Moon+ reader
+## Tested on
 
-# More information
-  - http://opds-spec.org
+- Moon+ reader
 
-# Binary release
-  - https://github.com/dubyte/dir2opds/releases
+## More information
 
+- <http://opds-spec.org>
 
-## Raspberry pi deployment using binary release
+## Binary release
+
+- <https://github.com/dubyte/dir2opds/releases>
+
+### Raspberry pi deployment using binary release
+
 ```bash
 cd && mkdir dir2opds && cd dir2opds
 
@@ -64,6 +73,7 @@ sudo systemctl start dir2opds.service
 ```
 
 /etc/systemd/system/dir2opds.service
+
 ```ini
 [Unit]
 Description=dir2opds
@@ -80,5 +90,11 @@ ExecStart=/home/pi/dir2opds/dir2opds -dir <FULL PATH OF BOOKS FOLDER> -port 8080
 WantedBy=multi-user.target
 ```
 
-# How to contribute
-  - [Contributing](CONTRIBUTING.md)
+## How to contribute
+
+- [Contributing](CONTRIBUTING.md)
+
+## Special thanks
+
+- @clach04: for testing and report missing content type for comics.
+- @masked-owl: for reporting security issue about http transversal.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dubyte/dir2opds
 
-go 1.21
+go 1.22
 
 require (
 	github.com/lann/builder v0.0.0-20150808151131-f22ce00fd939

--- a/main.go
+++ b/main.go
@@ -47,9 +47,9 @@ func main() {
 	fmt.Println(startValues())
 	var err error
 
-	// Use the absoluteCannonical path of the dir parm as the trustedRoot.
+	// Use the absoluteCanonical path of the dir parm as the trustedRoot.
 	// helpfull avoid http trasversal. https://github.com/dubyte/dir2opds/issues/17
-	*dirRoot, err = absoluteCannnonicalPath(*dirRoot)
+	*dirRoot, err = absoluteCanonicalPath(*dirRoot)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -78,15 +78,15 @@ func errorHandler(f func(http.ResponseWriter, *http.Request) error) http.Handler
 	}
 }
 
-// absoluteCannnonicalPath returns the cannonical path of the absolute path that was passed
-func absoluteCannnonicalPath(aPath string) (string, error) {
+// absoluteCanonicalPath returns the canonical path of the absolute path that was passed
+func absoluteCanonicalPath(aPath string) (string, error) {
 	// get absolute path
 	aPath, err := filepath.Abs(aPath)
 	if err != nil {
 		return "", fmt.Errorf("get absolute path %s: %w", aPath, err)
 	}
 
-	// get cannonical path
+	// get canonical path
 	aPath, err = filepath.EvalSymlinks(aPath)
 	if err != nil {
 		return "", fmt.Errorf("get connonical path from absolute path %s: %w", aPath, err)

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,4 +56,36 @@ func TestErrorHandler(t *testing.T) {
 
 	// assert
 	assert.Contains(t, buf.String(), `handling "/": scary error`)
+}
+
+func Test_absoluteCannnonicalPath(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("not possible to get current dir")
+	}
+	type args struct {
+		aPath string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{name: "dir relative path", args: args{aPath: "./opds"}, want: path.Join(wd, "opds"), wantErr: false},
+		{name: "dir not exists", args: args{aPath: "books"}, want: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := absoluteCannnonicalPath(tt.args.aPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("absoluteCannnonicalPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("absoluteCannnonicalPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -77,7 +77,7 @@ func Test_absoluteCannnonicalPath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := absoluteCannnonicalPath(tt.args.aPath)
+			got, err := absoluteCanonicalPath(tt.args.aPath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("absoluteCannnonicalPath() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
To fix this, I use the dir parameter, for example: './book,' then go to the absolute + canonical path of it. This value will become the trusted root patch, so later, I can use it to compare if it is the root of any request. If it is not, then it is violating. 