### PR TITLE
Added correct toolchain version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dubyte/dir2opds
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/lann/builder v0.0.0-20150808151131-f22ce00fd939


### PR DESCRIPTION
A correct version is in the form 1.x.y, see comment https://github.com/golang/go/issues/62278#issuecomment-1693538776

Otherwise build can fail with `go: download go1.22 for darwin/arm64: toolchain not available`