### PR TITLE
feat: ignore .files and add .calnotes and .caltrash to calibre option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2024-06-14
+
+### Changed
+
+- when calibre option is passed now also excludes .calnotes .caltrash
+
+### Added
+
+- hide-dot-files can be passed to ignere .files
+
 ## [1.0.6] - 2024-03-12
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -29,15 +29,17 @@ go install github.com/dubyte/dir2opds@latest
 ```bash
 Usage of dir2opds:
   -calibre
-      Hide files stored by calibre
+        Hide files stored by calibre.
   -debug
-      If it is set, it will log the requests
+        If it is set it will log the requests.
   -dir string
-      A directory with books (default "./books")
+        A directory with books. (default "./books")
+  -hide-dot-files
+        Hide files that starts with dot.
   -host string
-      The server will listen in this host (default "0.0.0.0")
+        The server will listen in this host. (default "0.0.0.0")
   -port string
-      The server will listen in this port (default "8080")
+        The server will listen in this port. (default "8080")
 ```
 
 ## Tested on
@@ -58,9 +60,9 @@ Usage of dir2opds:
 cd && mkdir dir2opds && cd dir2opds
 
 # get the binary
-wget https://github.com/dubyte/dir2opds/releases/download/v0.0.10/dir2opds_0.0.10_Linux_ARMv7.tar.gz
+wget https://github.com/dubyte/dir2opds/releases/download/v1.10.0/dir2opds_1.10.0_linux_armv7.tar.gz
 
-tar xvf dir2opds_0.0.10_Linux_ARMv7.tar.gz
+tar xvf dir2opds_1.10.0_linux_armv7.tar.gz
 
 sudo touch /etc/systemd/system/dir2opds.service
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -35,7 +35,7 @@ func TestHandler(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			// setup
-			s := service.OPDS{"testdata", true}
+			s := service.OPDS{"testdata", true, true}
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, tc.input, nil)
 			service.TimeNow = func() time.Time {

--- a/main.go
+++ b/main.go
@@ -29,11 +29,12 @@ import (
 )
 
 var (
-	port    = flag.String("port", "8080", "The server will listen in this port")
-	host    = flag.String("host", "0.0.0.0", "The server will listen in this host")
-	dirRoot = flag.String("dir", "./books", "A directory with books")
-	debug   = flag.Bool("debug", false, "If it is set it will log the requests")
-	calibre = flag.Bool("calibre", false, "Hide files stored by calibre")
+	port         = flag.String("port", "8080", "The server will listen in this port.")
+	host         = flag.String("host", "0.0.0.0", "The server will listen in this host.")
+	dirRoot      = flag.String("dir", "./books", "A directory with books.")
+	debug        = flag.Bool("debug", false, "If it is set it will log the requests.")
+	calibre      = flag.Bool("calibre", false, "Hide files stored by calibre.")
+	hideDotFiles = flag.Bool("hide-dot-files", false, "Hide files that starts with dot.")
 )
 
 func main() {
@@ -56,7 +57,7 @@ func main() {
 
 	log.Printf("%q will be used as your trusted root", *dirRoot)
 
-	s := service.OPDS{TrustedRoot: *dirRoot, IsCalibreLibrary: *calibre}
+	s := service.OPDS{TrustedRoot: *dirRoot, HideCalibreFiles: *calibre, HideDotFiles: *hideDotFiles}
 
 	http.HandleFunc("/", errorHandler(s.Handler))
 


### PR DESCRIPTION
- include new parameter to the app to explude dot files
- includes .calnotes and .caltrash when ignoring calibre files