### PR TITLE
podman container support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,11 @@
+# Stage 1: Build
+FROM docker.io/golang:1.23.3-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o /app/dir2opds
+
+# Stage 2: Final Image
+FROM docker.io/alpine
+COPY --from=builder /app/dir2opds /dir2opds

--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ ExecStart=/home/pi/dir2opds/dir2opds -dir <FULL PATH OF BOOKS FOLDER> -port 8080
 WantedBy=multi-user.target
 ```
 
+## Rootless Container with podman
+
+```sh
+# build image
+podman build -t localhost/dir2opds .
+# prepare Books directory
+mkdir /data/Books
+chown -R $USER:$USER /data/Books
+# run built image
+podman run --name dir2opds --rm --userns=keep-id --mount type=bind,src=/data/Books,dst=/books,Z --publish 8008:8080 -i -t localhost/dir2opds /dir2opds -debug
+```
+
+where
+
+- `/data/Books` is a path to directory containing books.
+
+Test from host with
+
+```sh
+curl http://localhost:8008
+```
+
 ## How to contribute
 
 - [Contributing](CONTRIBUTING.md)


### PR DESCRIPTION
Minimal container with ability to pass configuration options such as `-debug` when calling `podman run` or when configuring to run using podman systemd service integration.

Added `Containerfile` which is a podman specific name for `Dockerfile`.  It could be named `Dockerfile`, but it was not tested on Docker.

Added `README` instructions how to use `podman` to compile and to run container.