### PR TITLE
feat: add -no-pagination flag to disable pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ dist/
 # OS specific junk
 # macOS
 .DS_Store
+
+.opencode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2026-04-27
+
+### Added
+
+- **No Pagination option** — `-no-pagination` flag to disable pagination and show all entries in a single feed.
+
 ## [1.8.0] - 2026-03-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -45,11 +45,15 @@
 
 ## Quick start
 
-Using Docker (replace `v1.8.0` with the [latest release](https://github.com/dubyte/dir2opds/releases) if desired):
+Using Docker (replace `v1.9.0` with the [latest release](https://github.com/dubyte/dir2opds/releases) if desired):
 
 ```bash
-docker run -d -p 8080:8080 -v ./books:/books --name dir2opds ghcr.io/dubyte/dir2opds:v1.8.0
+docker run -d -p 8080:8080 -v ./books:/books --name dir2opds ghcr.io/dubyte/dir2opds:v1.9.0
 ```
+
+```
+
+Then open
 
 Then open `http://localhost:8080` in an OPDS client or browser.
 
@@ -99,8 +103,10 @@ dir2opds -dir /path/to/books -port 8080
 | `-log-format` | Log format: `json` (default), `text` |
 | `-mime-map` | Custom MIME types, e.g. `.mobi:application/x-mobipocket-ebook,.azw3:application/vnd.amazon.ebook` |
 | `-no-cache` | Add response headers to disable client caching |
+| `-no-pagination` | Disable pagination and show all entries in a single feed |
 | `-page-size` | Number of entries per page (default: `50`, max: `200`) |
 | `-port` | Listen port (default: `8080`) |
+| `-search` | Enable basic filename search |
 | `-search` | Enable basic filename search |
 | `-show-covers` | Use `cover.jpg` or `folder.jpg` as catalog covers |
 | `-sort` | Sort entries: `name`, `date`, or `size` (default: `name`) |
@@ -203,7 +209,24 @@ dir2opds -dir /books -page-size 100
 
 # Maximum page size: 200 entries
 dir2opds -dir /books -page-size 200
+
+# Disable pagination: show all entries
+dir2opds -dir /books -no-pagination
 ```
+
+### Disabling Pagination
+
+For small libraries or when using clients that work better with complete feeds, you can disable pagination entirely:
+
+```bash
+dir2opds -dir /books -no-pagination
+```
+
+When `-no-pagination` is set:
+- All entries are included in a single feed
+- No pagination navigation links are generated
+- The `?page=N` query parameter is ignored
+- Recommended for libraries with fewer than a few hundred books
 
 ### OPDS Feed Links
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -70,6 +70,7 @@ type OPDS struct {
 	ExtractMetadata  bool
 	BaseURL          string
 	PageSize         int
+	NoPagination     bool
 }
 
 type Catalog struct {
@@ -203,6 +204,14 @@ func (s OPDS) Scan(fPath string, urlPath string, page int) (*Catalog, error) {
 	pageSize := s.pageSize()
 	if page < 1 {
 		page = 1
+	}
+
+	// When NoPagination is enabled, show all entries on a single page
+	if s.NoPagination {
+		pageSize = total
+		if pageSize == 0 {
+			pageSize = 1 // Avoid division by zero
+		}
 	}
 
 	start := (page - 1) * pageSize
@@ -765,7 +774,7 @@ func (s OPDS) makeFeed(catalog *Catalog, req *http.Request) atom.Feed {
 			Build())
 	}
 
-	if catalog.Total > catalog.PageSize {
+	if !s.NoPagination && catalog.Total > catalog.PageSize {
 		totalPages := (catalog.Total + catalog.PageSize - 1) / catalog.PageSize
 		basePath := req.URL.Path
 		query := req.URL.Query()

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ var (
 	baseURL      = flag.String("url", "", "The base URL used for absolute links in the feed (e.g., https://opds.example.com).")
 	logFormat    = flag.String("log-format", "json", "Log format: json, text.")
 	pageSize     = flag.Int("page-size", 50, "Number of entries per page (0 for default, max 200).")
+	noPagination = flag.Bool("no-pagination", false, "Disable pagination and show all entries in a single feed.")
 )
 
 func main() {
@@ -98,6 +99,7 @@ func main() {
 		ExtractMetadata:  *extractMeta,
 		BaseURL:          *baseURL,
 		PageSize:         *pageSize,
+		NoPagination:     *noPagination,
 	}
 
 	http.HandleFunc("/", errorHandler(s.Handler))


### PR DESCRIPTION
Add new flag to disable pagination and show all entries in a single feed. This is useful for small libraries or clients that work better with complete feeds.

Changes:
- Add NoPagination field to OPDS struct
- Skip pagination logic when flag is enabled
- Suppress pagination navigation links in feed
- Update README with documentation
- Update CHANGELOG for v1.9.0