### PR TITLE
feat: OPDS 1.2 compliance core — self links, up links, open-access relation

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -760,11 +760,29 @@ func extractEpubCover(epubPath string) ([]byte, string, error) {
 }
 
 func (s OPDS) makeFeed(catalog *Catalog, req *http.Request) atom.Feed {
+	feedType := navigationType
+	if catalog.Type == pathTypeDirOfFiles {
+		feedType = "application/atom+xml;profile=opds-catalog;kind=acquisition"
+	}
+
 	feedBuilder := opds.FeedBuilder.
 		ID(catalog.ID).
 		Title(catalog.Title).
 		Updated(TimeNow()).
-		AddLink(opds.LinkBuilder.Rel("start").Href(s.joinURL("/")).Type(navigationType).Build())
+		AddLink(opds.LinkBuilder.Rel("start").Href(s.joinURL("/")).Type(navigationType).Build()).
+		AddLink(opds.LinkBuilder.Rel("self").Href(s.joinURL(req.URL.Path)).Type(feedType).Build())
+
+	if req.URL.Path != "/" && req.URL.Path != "" {
+		parentPath := path.Dir(req.URL.Path)
+		if parentPath == "." {
+			parentPath = "/"
+		}
+		feedBuilder = feedBuilder.AddLink(opds.LinkBuilder.
+			Rel("up").
+			Href(s.joinURL(parentPath)).
+			Type(navigationType).
+			Build())
+	}
 
 	if s.EnableSearch {
 		feedBuilder = feedBuilder.AddLink(opds.LinkBuilder.
@@ -792,11 +810,6 @@ func (s OPDS) makeFeed(catalog *Catalog, req *http.Request) atom.Feed {
 		totalPages := (catalog.Total + catalog.PageSize - 1) / catalog.PageSize
 		basePath := req.URL.Path
 		query := req.URL.Query()
-
-		feedType := "application/atom+xml;profile=opds-catalog;kind=navigation"
-		if catalog.Type == pathTypeDirOfFiles {
-			feedType = "application/atom+xml;profile=opds-catalog;kind=acquisition"
-		}
 
 		if catalog.Page > 1 {
 			feedBuilder = feedBuilder.AddLink(opds.LinkBuilder.
@@ -918,7 +931,7 @@ func getRel(name string, pathType int) string {
 	}
 
 	// mobi, epub, etc
-	return "http://opds-spec.org/acquisition"
+	return "http://opds-spec.org/acquisition/open-access"
 }
 
 func (s OPDS) getType(name string, pathType int) string {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -269,6 +269,7 @@ var feed = `<?xml version="1.0" encoding="UTF-8"?>
       <title>Catalog in /</title>
       <id>/</id>
       <link rel="start" href="/" type="application/atom+xml;profile=opds-catalog;kind=navigation"></link>
+      <link rel="self" href="/" type="application/atom+xml;profile=opds-catalog;kind=navigation"></link>
       <updated>2020-05-25T00:00:00+00:00</updated>
       <entry>
           <title>emptyFolder</title>
@@ -298,39 +299,41 @@ var acquisitionFeed = `<?xml version="1.0" encoding="UTF-8"?>
       <title>Catalog in /mybook</title>
       <id>/mybook</id>
       <link rel="start" href="/" type="application/atom+xml;profile=opds-catalog;kind=navigation"></link>
+      <link rel="self" href="/mybook" type="application/atom+xml;profile=opds-catalog;kind=acquisition"></link>
+      <link rel="up" href="/" type="application/atom+xml;profile=opds-catalog;kind=navigation"></link>
       <updated>2020-05-25T00:00:00+00:00</updated>
       <entry>
           <title>mybook copy.epub</title>
           <id>/mybookmybook copy.epub</id>
-          <link rel="http://opds-spec.org/acquisition" href="/mybook/mybook%20copy.epub" type="application/epub+zip" title="mybook copy.epub"></link>
+          <link rel="http://opds-spec.org/acquisition/open-access" href="/mybook/mybook%20copy.epub" type="application/epub+zip" title="mybook copy.epub"></link>
           <published>2020-05-25T00:00:00+00:00</published>
           <updated>2020-05-25T00:00:00+00:00</updated>
       </entry>
       <entry>
           <title>mybook copy.txt</title>
           <id>/mybookmybook copy.txt</id>
-          <link rel="http://opds-spec.org/acquisition" href="/mybook/mybook%20copy.txt" type="text/plain; charset=utf-8" title="mybook copy.txt"></link>
+          <link rel="http://opds-spec.org/acquisition/open-access" href="/mybook/mybook%20copy.txt" type="text/plain; charset=utf-8" title="mybook copy.txt"></link>
           <published>2020-05-25T00:00:00+00:00</published>
           <updated>2020-05-25T00:00:00+00:00</updated>
       </entry>
       <entry>
           <title>mybook.epub</title>
           <id>/mybookmybook.epub</id>
-          <link rel="http://opds-spec.org/acquisition" href="/mybook/mybook.epub" type="application/epub+zip" title="mybook.epub"></link>
+          <link rel="http://opds-spec.org/acquisition/open-access" href="/mybook/mybook.epub" type="application/epub+zip" title="mybook.epub"></link>
           <published>2020-05-25T00:00:00+00:00</published>
           <updated>2020-05-25T00:00:00+00:00</updated>
       </entry>
       <entry>
           <title>mybook.pdf</title>
           <id>/mybookmybook.pdf</id>
-          <link rel="http://opds-spec.org/acquisition" href="/mybook/mybook.pdf" type="application/pdf" title="mybook.pdf"></link>
+          <link rel="http://opds-spec.org/acquisition/open-access" href="/mybook/mybook.pdf" type="application/pdf" title="mybook.pdf"></link>
           <published>2020-05-25T00:00:00+00:00</published>
           <updated>2020-05-25T00:00:00+00:00</updated>
       </entry>
       <entry>
           <title>mybook.txt</title>
           <id>/mybookmybook.txt</id>
-          <link rel="http://opds-spec.org/acquisition" href="/mybook/mybook.txt" type="text/plain; charset=utf-8" title="mybook.txt"></link>
+          <link rel="http://opds-spec.org/acquisition/open-access" href="/mybook/mybook.txt" type="text/plain; charset=utf-8" title="mybook.txt"></link>
           <published>2020-05-25T00:00:00+00:00</published>
           <updated>2020-05-25T00:00:00+00:00</updated>
       </entry>


### PR DESCRIPTION
## What

Improves OPDS 1.2 compliance and client compatibility with three additive metadata changes:

1. **`rel="self"` links on all feeds** — OPDS 1.2 specifies feeds SHOULD contain a self link. Enables client bookmarking and feed identity.
2. **`rel="up"` links for breadcrumb navigation** — Points to parent directory in subfolder feeds. OPDS 1.2 recommended for hierarchical navigation.
3. **`open-access` acquisition relation** — Semantically correct for a free local file server with no DRM or paywalls. Modern clients (Thorium, Aldiko Next) show "free" badges.

## Changes

- `internal/service/service.go`:
  - Compute `feedType` early and reuse for `self` link and pagination links
  - Add `self` link to every feed
  - Add `up` link when `req.URL.Path` is not root
  - Change `getRel()` to return `acquisition/open-access` for book files
- `internal/service/service_test.go`:
  - Update `feed` fixture with `self` link
  - Update `acquisitionFeed` fixture with `self`, `up`, and `open-access` relations

## Verification

- `go test ./...` passes
- `go vet ./...` clean
- No breaking changes — all additive metadata

## Scope

Part of the OPDS 1.2 improvement plan. Tier 1 + Tier 2.2 items.