### PR TITLE
feat: add crawlable feed endpoint for aggregators and search engines

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -500,6 +500,11 @@ func (s OPDS) Handler(w http.ResponseWriter, req *http.Request) error {
 		s.SortBy = sortBy
 	}
 
+	complete := req.URL.Query().Get("complete") == "true"
+	if complete {
+		s.NoPagination = true
+	}
+
 	catalog, err := s.Scan(fPath, urlPath, page)
 	if err != nil {
 		slog.Error("error scanning path", "error", err)
@@ -547,7 +552,6 @@ func (s OPDS) Handler(w http.ResponseWriter, req *http.Request) error {
 	var content []byte
 	// it is an acquisition feed
 	if catalog.Type == pathTypeDirOfFiles {
-		navFeed.Opds = "http://opds-spec.org/2010/catalog"
 		navFeed.Opds = "http://opds-spec.org/2010/catalog"
 		acFeed := &opds.AcquisitionFeed{Feed: &navFeed, Dc: "http://purl.org/dc/terms/"}
 		content, err = xml.MarshalIndent(acFeed, "  ", "    ")
@@ -866,6 +870,17 @@ func (s OPDS) makeFeed(catalog *Catalog, req *http.Request) opds.Feed {
 				Type(feedType).
 				Build())
 		}
+	}
+
+	if !s.NoPagination && catalog.Total > catalog.PageSize {
+		crawlableQuery := cloneURLValues(req.URL.Query())
+		crawlableQuery.Set("complete", "true")
+		crawlableURL := req.URL.Path + "?" + crawlableQuery.Encode()
+		feedBuilder = feedBuilder.AddLink(opds.LinkBuilder.
+			Rel("http://opds-spec.org/crawlable").
+			Href(s.joinURL(crawlableURL)).
+			Type(feedType).
+			Build())
 	}
 
 	if catalog.Total > 1 {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -409,3 +409,52 @@ func TestContentRange(t *testing.T) {
 		assert.Equal(t, http.StatusRequestedRangeNotSatisfiable, resp.StatusCode)
 	})
 }
+
+func TestCrawlableFeed(t *testing.T) {
+	s := service.OPDS{
+		TrustedRoot:      "testdata",
+		HideCalibreFiles: true,
+		HideDotFiles:     true,
+		PageSize:         2,
+	}
+
+	t.Run("crawlable link appears in paginated feed", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		service.TimeNow = func() time.Time {
+			return time.Date(2020, 05, 25, 00, 00, 00, 0, time.UTC)
+		}
+
+		err := s.Handler(w, req)
+		require.NoError(t, err)
+
+		resp := w.Result()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.Contains(t, string(body), `rel="http://opds-spec.org/crawlable"`)
+		assert.Contains(t, string(body), `complete=true`)
+	})
+
+	t.Run("complete=true returns all entries unpaginated", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/?complete=true", nil)
+		service.TimeNow = func() time.Time {
+			return time.Date(2020, 05, 25, 00, 00, 00, 0, time.UTC)
+		}
+
+		err := s.Handler(w, req)
+		require.NoError(t, err)
+
+		resp := w.Result()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.NotContains(t, string(body), `rel="first"`)
+		assert.NotContains(t, string(body), `rel="next"`)
+		assert.NotContains(t, string(body), `rel="http://opds-spec.org/crawlable"`)
+		assert.Contains(t, string(body), "<title>emptyFolder</title>")
+		assert.Contains(t, string(body), "<title>mybook</title>")
+		assert.Contains(t, string(body), "<title>new folder</title>")
+	})
+}


### PR DESCRIPTION
## What

Adds a crawlable feed endpoint for OPDS aggregators, search engines, and clients that support full-library sync.

## Changes

- **Crawlable feed**: `GET /?complete=true` returns all entries in a single unpaginated feed
- **Crawlable link**: Paginated feeds include `rel="http://opds-spec.org/crawlable"` pointing to `?complete=true`
- **Query parameter**: `?complete=true` temporarily disables pagination for that request only
- **Clean output**: Complete feeds omit pagination links (`first`, `next`, etc.) and the crawlable link itself

## Behavior

| Request | Pagination | Crawlable link |
|---------|-----------|----------------|
| Regular feed with few entries | None | No |
| Regular feed with many entries | Active | Yes |
| `?complete=true` | Disabled | No |

## Files

- `internal/service/service.go`: complete query param handling, crawlable link generation
- `internal/service/service_test.go`: tests for crawlable link presence and complete feed behavior

## Verification

- `go test ./...` passes
- `go vet ./...` clean

## Scope

Final PR from the OPDS 1.2 improvement plan. Follows #53 (compliance core) and #54 (facet links).
