### PR TITLE
chore: release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-07-11
+
+### Added
+
+- **OPDS 1.2 self links** — All feeds now include `rel="self"` links pointing to their canonical URL.
+- **OPDS 1.2 up links** — Subfolder feeds include `rel="up"` links for breadcrumb navigation.
+- **OPDS 1.2 open-access relation** — Book acquisition links use `http://opds-spec.org/acquisition/open-access` instead of the generic `acquisition` relation, enabling "free" badges in modern clients.
+- **OPDS 1.2 facet links** — Feeds include `rel="http://opds-spec.org/facet"` links for name/date/size sorting with `opds:facetGroup="Sort By"` and `opds:activeFacet="true"` attributes.
+- **OPDS 1.2 crawlable feed** — `?complete=true` query parameter returns all entries in a single unpaginated feed. Paginated feeds include `rel="http://opds-spec.org/crawlable"` links for aggregators and search engines.
+- **Custom OPDS/Atom structs** — Replaced `golang.org/x/tools/blog/atom` with native OPDS-aware structs supporting custom XML attributes.
+
 ### Changed
 
 - **Default flags for OPDS compliance** — Changed defaults for `-hide-calibre-files` (formerly `-calibre`), `-hide-dot-files`, `-extract-metadata`, and `-show-covers` from `false` to `true`. This produces correct OPDS feeds out of the box without manual configuration.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -9,7 +9,7 @@ Download binaries for Linux, macOS, Windows, and other platforms from the [Relea
 ## Docker
 
 ```bash
-docker pull ghcr.io/dubyte/dir2opds:v1.8.0
+docker pull ghcr.io/dubyte/dir2opds:v1.10.0
 ```
 
 ```bash
@@ -20,17 +20,17 @@ docker run \
   -p 8080:8080 \
   -v ./books:/books \
   --name dir2opds \
-  ghcr.io/dubyte/dir2opds:v1.8.0
+  ghcr.io/dubyte/dir2opds:v1.10.0
 ```
 
-Use a specific [release](https://github.com/dubyte/dir2opds/releases) tag instead of `v1.8.0` if needed. Thanks to [rockavoldy](https://hub.docker.com/u/rockavoldy) for the run example.
+Use a specific [release](https://github.com/dubyte/dir2opds/releases) tag instead of `v1.10.0` if needed. Thanks to [rockavoldy](https://hub.docker.com/u/rockavoldy) for the run example.
 
 ## Podman
 
 **Pre-built image:**
 
 ```bash
-podman pull ghcr.io/dubyte/dir2opds:v1.8.0
+podman pull ghcr.io/dubyte/dir2opds:v1.10.0
 ```
 
 **Build from source:**
@@ -49,7 +49,7 @@ podman run \
   -p 8080:8080 \
   -v ./books:/books \
   --name dir2opds \
-  ghcr.io/dubyte/dir2opds:v1.8.0
+  ghcr.io/dubyte/dir2opds:v1.10.0
 ```
 
 **Rootless** (e.g. non-root user, SELinux): use a bind mount with the `Z` option and keep the user namespace:
@@ -64,18 +64,18 @@ podman run \
   -p 8080:8080 \
   -v /data/Books:/books:Z \
   --name dir2opds \
-  ghcr.io/dubyte/dir2opds:v1.8.0
+  ghcr.io/dubyte/dir2opds:v1.10.0
 ```
 
-Add `-debug` for request logging, e.g. `... ghcr.io/dubyte/dir2opds:v1.8.0 /dir2opds -debug`.
+Add `-debug` for request logging, e.g. `... ghcr.io/dubyte/dir2opds:v1.10.0 /dir2opds -debug`.
 
 ## Raspberry Pi (binary + systemd)
 
 ```bash
 cd && mkdir dir2opds && cd dir2opds
-# Replace v1.8.0 and the asset name with the release that matches your system
-wget https://github.com/dubyte/dir2opds/releases/download/v1.8.0/dir2opds_1.8.0_linux_armv7.tar.gz
-tar xvf dir2opds_1.8.0_linux_armv7.tar.gz
+# Replace v1.10.0 and the asset name with the release that matches your system
+wget https://github.com/dubyte/dir2opds/releases/download/v1.10.0/dir2opds_1.10.0_linux_armv7.tar.gz
+tar xvf dir2opds_1.10.0_linux_armv7.tar.gz
 
 sudo nano /etc/systemd/system/dir2opds.service
 # Paste the unit below, then set the full path of your books folder in -dir

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ dir2opds is ideal for anyone who wants a **self-hosted digital library** without
 
 ## Quick start
 
-Using Docker (replace `v1.9.0` with the [latest release](https://github.com/dubyte/dir2opds/releases) if desired):
+Using Docker (replace `v1.10.0` with the [latest release](https://github.com/dubyte/dir2opds/releases) if desired):
 
 ```bash
-docker run -d -p 8080:8080 -v ./books:/books --name dir2opds ghcr.io/dubyte/dir2opds:v1.9.0
+docker run -d -p 8080:8080 -v ./books:/books --name dir2opds ghcr.io/dubyte/dir2opds:v1.10.0
 ```
 
 ```
@@ -122,7 +122,7 @@ dir2opds -dir /path/to/books -port 8080
 | `-sort` | Sort entries: `name`, `date`, or `size` (default: `name`) |
 | `-url` | The base URL used for absolute links in the feed (e.g., `https://opds.example.com`) |
 
-### Legacy Behavior (Pre-v2.0.0)
+### Legacy Behavior (Pre-v1.10.0)
 
 If you need the old behavior where all files are shown and no metadata is extracted:
 


### PR DESCRIPTION
## What

Release v1.10.0 — updates version references and CHANGELOG for the new release.

## Version Choice: v1.10.0 over v2.0.0

This release is **backward compatible** — all changes are additive or opt-out:
- Old `-calibre` flag still works with deprecation warning
- Old defaults can be restored with `-hide-calibre-files=false -hide-dot-files=false -extract-metadata=false -show-covers=false`
- No breaking changes to feed structure or API

SemVer dictates a minor version bump for backward-compatible functionality additions.

## Changes

### Documentation
- **CHANGELOG.md**: Added v1.10.0 section with all OPDS 1.2 improvements and flag changes
- **README.md**: Updated Docker example to `ghcr.io/dubyte/dir2opds:v1.10.0`
- **INSTALLATION.md**: Updated Docker, Podman, and Raspberry Pi examples to v1.10.0

## Verification

- `go test ./...` passes
- `go vet ./...` clean
