### PR TITLE
docs: update CHANGELOG and README for v1.10.1 metadata features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-07-11
+
+### Added
+
+- **EPUB description extraction** — `<dc:description>` metadata is now extracted and emitted as `<atom:summary>` in acquisition feeds, enabling richer book previews in OPDS clients.
+- **EPUB series metadata extraction** — `calibre:series` and `calibre:series_index` are extracted and emitted as `<dc:series>` and `<dc:seriesPosition>`, enabling reading order views in supporting clients.
+- **EPUB subject/category extraction** — `<dc:subject>` tags are extracted and emitted as `<atom:category>` elements, enabling genre/subject browsing.
+
 ## [1.10.0] - 2026-07-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **EPUB description extraction** — `<dc:description>` metadata is now extracted and emitted as `<atom:summary>` in acquisition feeds, enabling richer book previews in OPDS clients.
 - **EPUB series metadata extraction** — `calibre:series` and `calibre:series_index` are extracted and emitted as `<dc:series>` and `<dc:seriesPosition>`, enabling reading order views in supporting clients.
 - **EPUB subject/category extraction** — `<dc:subject>` tags are extracted and emitted as `<atom:category>` elements, enabling genre/subject browsing.
+- **PDF metadata extraction** — Replaced regex-based PDF metadata scanner with proper `rsc.io/pdf` parser. Now extracts Title, Author, Subject (→ `<atom:summary>`), and Keywords (→ `<atom:category>`).
 
 ## [1.10.0] - 2026-07-11
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -9,7 +9,7 @@ Download binaries for Linux, macOS, Windows, and other platforms from the [Relea
 ## Docker
 
 ```bash
-docker pull ghcr.io/dubyte/dir2opds:v1.10.0
+docker pull ghcr.io/dubyte/dir2opds:v1.10.1
 ```
 
 ```bash
@@ -20,17 +20,17 @@ docker run \
   -p 8080:8080 \
   -v ./books:/books \
   --name dir2opds \
-  ghcr.io/dubyte/dir2opds:v1.10.0
+  ghcr.io/dubyte/dir2opds:v1.10.1
 ```
 
-Use a specific [release](https://github.com/dubyte/dir2opds/releases) tag instead of `v1.10.0` if needed. Thanks to [rockavoldy](https://hub.docker.com/u/rockavoldy) for the run example.
+Use a specific [release](https://github.com/dubyte/dir2opds/releases) tag instead of `v1.10.1` if needed. Thanks to [rockavoldy](https://hub.docker.com/u/rockavoldy) for the run example.
 
 ## Podman
 
 **Pre-built image:**
 
 ```bash
-podman pull ghcr.io/dubyte/dir2opds:v1.10.0
+podman pull ghcr.io/dubyte/dir2opds:v1.10.1
 ```
 
 **Build from source:**
@@ -49,7 +49,7 @@ podman run \
   -p 8080:8080 \
   -v ./books:/books \
   --name dir2opds \
-  ghcr.io/dubyte/dir2opds:v1.10.0
+  ghcr.io/dubyte/dir2opds:v1.10.1
 ```
 
 **Rootless** (e.g. non-root user, SELinux): use a bind mount with the `Z` option and keep the user namespace:
@@ -64,7 +64,7 @@ podman run \
   -p 8080:8080 \
   -v /data/Books:/books:Z \
   --name dir2opds \
-  ghcr.io/dubyte/dir2opds:v1.10.0
+  ghcr.io/dubyte/dir2opds:v1.10.1
 ```
 
 Add `-debug` for request logging, e.g. `... ghcr.io/dubyte/dir2opds:v1.10.0 /dir2opds -debug`.
@@ -73,9 +73,9 @@ Add `-debug` for request logging, e.g. `... ghcr.io/dubyte/dir2opds:v1.10.0 /dir
 
 ```bash
 cd && mkdir dir2opds && cd dir2opds
-# Replace v1.10.0 and the asset name with the release that matches your system
-wget https://github.com/dubyte/dir2opds/releases/download/v1.10.0/dir2opds_1.10.0_linux_armv7.tar.gz
-tar xvf dir2opds_1.10.0_linux_armv7.tar.gz
+# Replace v1.10.1 and the asset name with the release that matches your system
+wget https://github.com/dubyte/dir2opds/releases/download/v1.10.1/dir2opds_1.10.1_linux_armv7.tar.gz
+tar xvf dir2opds_1.10.1_linux_armv7.tar.gz
 
 sudo nano /etc/systemd/system/dir2opds.service
 # Paste the unit below, then set the full path of your books folder in -dir

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ dir2opds -dir /path/to/books -port 8080
 | `-dir` | Directory with books (default: `./books`) |
 | `-enable-cache` | Enable ETag/Last-Modified headers for conditional requests (bandwidth optimization) |
 | `-enable-html` | Enable web-friendly HTML view for browsers |
-| `-extract-metadata` | Extract title/author from EPUB and PDF, and covers from EPUB (default: `true`) |
+| `-extract-metadata` | Extract title/author/description/series/subjects from EPUB, title/author from PDF, and covers from EPUB (default: `true`) |
 | `-gzip` | Enable gzip compression for responses (reduces bandwidth) |
 | `-hide-dot-files` | Hide files whose names start with a dot (default: `true`) |
 | `-host` | Listen address (default: `0.0.0.0`) |

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ dir2opds is ideal for anyone who wants a **self-hosted digital library** without
 
 ## Quick start
 
-Using Docker (replace `v1.10.0` with the [latest release](https://github.com/dubyte/dir2opds/releases) if desired):
+Using Docker (replace `v1.10.1` with the [latest release](https://github.com/dubyte/dir2opds/releases) if desired):
 
 ```bash
-docker run -d -p 8080:8080 -v ./books:/books --name dir2opds ghcr.io/dubyte/dir2opds:v1.10.0
+docker run -d -p 8080:8080 -v ./books:/books --name dir2opds ghcr.io/dubyte/dir2opds:v1.10.1
 ```
 
 ```


### PR DESCRIPTION
Update documentation to reflect the three new EPUB metadata extraction features merged in PRs #59, #60, and #61.

Changes:
- CHANGELOG.md: Added v1.10.1 section with description, series, and subject extraction
- README.md: Updated -extract-metadata flag description to include all fields